### PR TITLE
fix footer link to PEDP

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -28,19 +28,19 @@ If you install NVM using Homebrew, make sure to read the output in terminal afte
 
 Once you install NVM, don't forget to install Node! This is included in the linked tutorial above. This will also install `npm` which you need for the steps below.
 
-After you've downloaded the nvm and the latest node (using the above steps) also install node version 14 by:
+After you've downloaded the nvm and the latest node (using the above steps) also install node version 18 by:
 
-`nvm install 14`
+`nvm install 18`
 
 You should then be able to switch to that version of node by:
 
-`nvm use 14`
+`nvm use 18`
 
-To validate you are using node 14, type:
+To validate you are using node 18, type:
 
 `node -v` 
 
-This should return *Now using node 14.x.x (npm v6.x.x)*
+This should return *Now using node 18.x.x (npm v6.x.x)*
 
 #### Install Yarn
 

--- a/client/src/components/J40Footer/__snapshots__/J40Footer.spec.tsx.snap
+++ b/client/src/components/J40Footer/__snapshots__/J40Footer.spec.tsx.snap
@@ -34,7 +34,7 @@ exports[`J40Footer renders correctly 1`] = `
                   <a
                     class="usa-link usa-link--external footer-link-first-child"
                     data-cy="check-out-the-code-on-github"
-                    href="https://github.com/edgi-govdata-archiving/j40-cejst-2"
+                    href="https://github.com/Public-Environmental-Data-Partners/j40-cejst-2"
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/client/src/constants.tsx
+++ b/client/src/constants.tsx
@@ -1,2 +1,3 @@
-export const GITHUB_LINK = 'https://github.com/edgi-govdata-archiving/j40-cejst-2';
+export const GITHUB_LINK =
+  'https://github.com/Public-Environmental-Data-Partners/j40-cejst-2';
 export const GITHUB_LINK_ES = `${GITHUB_LINK}/blob/main/README-es.md`;

--- a/client/src/pages/tests/__snapshots__/about.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/about.test.tsx.snap
@@ -337,7 +337,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external footer-link-first-child"
                     data-cy="check-out-the-code-on-github"
-                    href="https://github.com/edgi-govdata-archiving/j40-cejst-2"
+                    href="https://github.com/Public-Environmental-Data-Partners/j40-cejst-2"
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/client/src/pages/tests/__snapshots__/contact.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/contact.test.tsx.snap
@@ -326,7 +326,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external footer-link-first-child"
                     data-cy="check-out-the-code-on-github"
-                    href="https://github.com/edgi-govdata-archiving/j40-cejst-2"
+                    href="https://github.com/Public-Environmental-Data-Partners/j40-cejst-2"
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/client/src/pages/tests/__snapshots__/downloads.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/downloads.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external footer-link-first-child"
                     data-cy="check-out-the-code-on-github"
-                    href="https://github.com/edgi-govdata-archiving/j40-cejst-2"
+                    href="https://github.com/Public-Environmental-Data-Partners/j40-cejst-2"
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/client/src/pages/tests/__snapshots__/freqAskedQuestions.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/freqAskedQuestions.test.tsx.snap
@@ -924,7 +924,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external footer-link-first-child"
                     data-cy="check-out-the-code-on-github"
-                    href="https://github.com/edgi-govdata-archiving/j40-cejst-2"
+                    href="https://github.com/Public-Environmental-Data-Partners/j40-cejst-2"
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
@@ -2980,7 +2980,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external footer-link-first-child"
                     data-cy="check-out-the-code-on-github"
-                    href="https://github.com/edgi-govdata-archiving/j40-cejst-2"
+                    href="https://github.com/Public-Environmental-Data-Partners/j40-cejst-2"
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/client/src/pages/tests/__snapshots__/privacy.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/privacy.test.tsx.snap
@@ -450,7 +450,7 @@ exports[`rendering of the Privacy Policy page matches Privacy Policy page snapsh
                   <a
                     class="usa-link usa-link--external footer-link-first-child"
                     data-cy="check-out-the-code-on-github"
-                    href="https://github.com/edgi-govdata-archiving/j40-cejst-2"
+                    href="https://github.com/Public-Environmental-Data-Partners/j40-cejst-2"
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/client/src/pages/tests/__snapshots__/techSupportDoc.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/techSupportDoc.test.tsx.snap
@@ -266,7 +266,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external footer-link-first-child"
                     data-cy="check-out-the-code-on-github"
-                    href="https://github.com/edgi-govdata-archiving/j40-cejst-2"
+                    href="https://github.com/Public-Environmental-Data-Partners/j40-cejst-2"
                     rel="noreferrer"
                     target="_blank"
                   >


### PR DESCRIPTION
This is a quick test to see if the action checks of build, test and lint pass.... OK it does pass!

How to test this PR:
1. Spin up the Gatsby application locally
2. Check if the footer link is no longer broken

How to spin up the Gatsby app:

1. Open your terminal
2. switch to node version 18. If you have nvm installed you can simply type `nvm use 18`
3. `npm install`
4. `npm start`

This should allow you to run the gatsby app locally. This might be a good way to check each others work until we have preview links up

